### PR TITLE
Создана сущность Category

### DIFF
--- a/src/main/java/com/homegarden/store/backend/model/entity/Category.java
+++ b/src/main/java/com/homegarden/store/backend/model/entity/Category.java
@@ -1,0 +1,21 @@
+package com.homegarden.store.backend.model.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "categories")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Category {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String name;
+}


### PR DESCRIPTION
Создана JPA-сущность `CategoryEntity` в пакете `model.entity`.

- Используется Lombok (`@Data`, `@NoArgsConstructor`, `@AllArgsConstructor`)
- Поля: `id`, `name`
- Название категории уникально (аннотация `@Column(unique = true)`)
- Настроена аннотация `@Entity` и `@Table(name = "categories")`

Папка: `feature/category-entity`
