### PR TITLE
Добавлен интерфейс CategoryRepository

### DIFF
--- a/src/main/java/com/homegarden/store/backend/repository/CategoryRepository.java
+++ b/src/main/java/com/homegarden/store/backend/repository/CategoryRepository.java
@@ -4,8 +4,6 @@ import com.homegarden.store.backend.model.entity.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.Optional;
-
 @Repository
 public interface CategoryRepository extends JpaRepository<Category, Long> {
 


### PR DESCRIPTION
Создан интерфейс CategoryRepository для работы с таблицей категорий в базе данных.

Содержит:
Наследование от JpaRepository<Category, Long> — доступ к CRUD-операциям
Аннотирован @Repository для регистрации Spring-контейнером.
