### PR TITLE
Unit Tests for Payment (Converter; Controller; Service)

### DIFF
--- a/src/test/java/com/homegarden/store/backend/controller/PaymentControllerTest.java
+++ b/src/test/java/com/homegarden/store/backend/controller/PaymentControllerTest.java
@@ -1,0 +1,117 @@
+package com.homegarden.store.backend.controller;
+
+import com.homegarden.store.backend.converter.PaymentConverter;
+import com.homegarden.store.backend.dto.PaymentCreateDto;
+import com.homegarden.store.backend.dto.PaymentResponseDto;
+import com.homegarden.store.backend.entity.Payment;
+import com.homegarden.store.backend.enums.PaymentStatus;
+import com.homegarden.store.backend.service.PaymentService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.ResponseEntity;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+class PaymentControllerTest {
+
+    @Mock
+    private PaymentService paymentService;
+
+    @Mock
+    private PaymentConverter paymentConverter;
+
+    @InjectMocks
+    private PaymentController paymentController;
+
+    private Payment payment;
+    private PaymentResponseDto responseDto;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+
+        payment = Payment.builder()
+                .id(1L)
+                .amount(BigDecimal.valueOf(100))
+                .status(PaymentStatus.SUCCESS)
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+
+        responseDto = new PaymentResponseDto(
+                1L, 2L, BigDecimal.valueOf(100), PaymentStatus.SUCCESS,
+                payment.getCreatedAt(), payment.getUpdatedAt()
+        );
+    }
+
+    @Test
+    void getAllPayments_shouldReturnList() {
+        when(paymentService.getAllPayments()).thenReturn(List.of(payment));
+        when(paymentConverter.toDto(any())).thenReturn(responseDto);
+
+        ResponseEntity<List<PaymentResponseDto>> response = paymentController.getAllPayments();
+        List<PaymentResponseDto> result = response.getBody();
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).paymentId()).isEqualTo(1L);
+    }
+
+    @Test
+    void create_shouldReturnCreatedPayment() {
+        PaymentCreateDto dto = new PaymentCreateDto(2L);
+
+        when(paymentConverter.toEntity(any())).thenReturn(payment);
+        when(paymentService.create(any())).thenReturn(payment);
+        when(paymentConverter.toDto(any())).thenReturn(responseDto);
+
+        ResponseEntity<PaymentResponseDto> response = paymentController.create(dto);
+        PaymentResponseDto result = response.getBody();
+
+        assertThat(result.paymentId()).isEqualTo(1L);
+    }
+
+    @Test
+    void confirm_shouldReturnUpdatedPayment() {
+        when(paymentService.confirm(eq(1L), eq(PaymentStatus.SUCCESS))).thenReturn(payment);
+        when(paymentConverter.toDto(any())).thenReturn(responseDto);
+
+        ResponseEntity<PaymentResponseDto> response = paymentController.confirm(1L, PaymentStatus.SUCCESS);
+        PaymentResponseDto result = response.getBody();
+
+        assertThat(result.paymentId()).isEqualTo(1L);
+        assertThat(result.status()).isEqualTo(PaymentStatus.SUCCESS);
+    }
+
+    @Test
+    void getById_shouldReturnPayment() {
+        when(paymentService.getById(1L)).thenReturn(payment);
+        when(paymentConverter.toDto(any())).thenReturn(responseDto);
+
+        ResponseEntity<PaymentResponseDto> response = paymentController.getById(1L);
+        PaymentResponseDto result = response.getBody();
+
+        assertThat(result.paymentId()).isEqualTo(1L);
+    }
+
+    @Test
+    void getPaymentsByOrder_shouldReturnList() {
+        when(paymentService.getAllByOrder(2L)).thenReturn(List.of(payment));
+        when(paymentConverter.toDto(any())).thenReturn(responseDto);
+
+        ResponseEntity<List<PaymentResponseDto>> response = paymentController.getPaymentsByOrder(2L);
+        List<PaymentResponseDto> result = response.getBody();
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).paymentId()).isEqualTo(1L);
+    }
+}

--- a/src/test/java/com/homegarden/store/backend/converter/PaymentConverterTest.java
+++ b/src/test/java/com/homegarden/store/backend/converter/PaymentConverterTest.java
@@ -1,0 +1,63 @@
+package com.homegarden.store.backend.converter;
+
+import com.homegarden.store.backend.dto.PaymentCreateDto;
+import com.homegarden.store.backend.dto.PaymentResponseDto;
+import com.homegarden.store.backend.entity.Order;
+import com.homegarden.store.backend.entity.Payment;
+import com.homegarden.store.backend.enums.PaymentStatus;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PaymentConverterTest {
+
+    private final PaymentConverter converter = new PaymentConverter();
+
+    @Test
+    void toEntity_shouldMapFieldsCorrectly() {
+        Long orderId = 42L;
+        PaymentCreateDto dto = new PaymentCreateDto(orderId);
+
+        Payment entity = converter.toEntity(dto);
+
+        assertThat(entity).isNotNull();
+        assertThat(entity.getOrder()).isNotNull();
+        assertThat(entity.getOrder().getOrderId()).isEqualTo(orderId);
+    }
+
+    @Test
+    void toDto_shouldMapFieldsCorrectly() {
+        Long paymentId = 1L;
+        Long orderId = 100L;
+        BigDecimal amount = BigDecimal.valueOf(200);
+        PaymentStatus status = PaymentStatus.SUCCESS;
+        LocalDateTime createdAt = LocalDateTime.now();
+        LocalDateTime updatedAt = LocalDateTime.now();
+
+        Order order = Order.builder()
+                .orderId(orderId)
+                .build();
+
+        Payment payment = Payment.builder()
+                .id(paymentId)
+                .order(order)
+                .amount(amount)
+                .status(status)
+                .createdAt(createdAt)
+                .updatedAt(updatedAt)
+                .build();
+
+        PaymentResponseDto dto = converter.toDto(payment);
+
+        assertThat(dto).isNotNull();
+        assertThat(dto.paymentId()).isEqualTo(paymentId);
+        assertThat(dto.orderId()).isEqualTo(orderId);
+        assertThat(dto.amount()).isEqualTo(amount);
+        assertThat(dto.status()).isEqualTo(status);
+        assertThat(dto.createdAt()).isEqualTo(createdAt);
+        assertThat(dto.updatedAt()).isEqualTo(updatedAt);
+    }
+}

--- a/src/test/java/com/homegarden/store/backend/service/PaymentServiceImplTest.java
+++ b/src/test/java/com/homegarden/store/backend/service/PaymentServiceImplTest.java
@@ -1,0 +1,161 @@
+package com.homegarden.store.backend.service;
+
+import com.homegarden.store.backend.entity.Order;
+import com.homegarden.store.backend.entity.Payment;
+import com.homegarden.store.backend.entity.User;
+import com.homegarden.store.backend.enums.PaymentStatus;
+import com.homegarden.store.backend.enums.Status;
+import com.homegarden.store.backend.exception.DoublePaymentException;
+import com.homegarden.store.backend.repository.PaymentRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+class PaymentServiceImplTest {
+
+    @Mock
+    private PaymentRepository paymentRepository;
+
+    @Mock
+    private OrderService orderService;
+
+    @Mock
+    private UserService userService;
+
+    @InjectMocks
+    private PaymentServiceImpl paymentService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void createPayment_shouldSetAmountAndStatus() {
+        Long orderId = 1L;
+        BigDecimal total = BigDecimal.valueOf(1000);
+
+        Order order = Order.builder()
+                .orderId(orderId)
+                .status(Status.CREATED)
+                .orderTotalSum(total)
+                .build();
+
+        Payment payment = Payment.builder()
+                .order(Order.builder().orderId(orderId).build())
+                .build();
+
+        when(orderService.getById(orderId)).thenReturn(order);
+        when(paymentRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        Payment saved = paymentService.create(payment);
+
+        assertThat(saved.getAmount()).isEqualTo(total);
+        assertThat(saved.getOrder().getStatus()).isEqualTo(Status.AWAITING_PAYMENT);
+
+        verify(paymentRepository).save(any());
+    }
+
+    @Test
+    void createPayment_shouldThrowIfOrderHasUnpaidPayment() {
+        Order order = Order.builder()
+                .orderId(1L)
+                .status(Status.AWAITING_PAYMENT)
+                .build();
+
+        Payment payment = Payment.builder()
+                .order(order)
+                .build();
+
+        when(orderService.getById(1L)).thenReturn(order);
+
+        assertThatThrownBy(() -> paymentService.create(payment))
+                .isInstanceOf(DoublePaymentException.class);
+
+        verify(paymentRepository, never()).save(any());
+    }
+
+    @Test
+    void getAllPayments_shouldReturnList() {
+        List<Payment> payments = List.of(new Payment(), new Payment());
+        when(paymentRepository.findAll()).thenReturn(payments);
+
+        List<Payment> result = paymentService.getAllPayments();
+
+        assertThat(result).hasSize(2);
+        verify(paymentRepository).findAll();
+    }
+
+    @Test
+    void confirm_shouldUpdateStatusAndOrder() {
+        Long paymentId = 5L;
+        PaymentStatus newStatus = PaymentStatus.SUCCESS;
+
+        User user = new User();
+        Order order = Order.builder()
+                .status(Status.CREATED)
+                .user(user)
+                .build();
+
+        Payment payment = Payment.builder()
+                .id(paymentId)
+                .status(PaymentStatus.PENDING)
+                .order(order)
+                .build();
+
+        when(paymentRepository.findById(paymentId)).thenReturn(Optional.of(payment));
+        when(userService.getCurrentUser()).thenReturn(user);
+        when(paymentRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        Payment updated = paymentService.confirm(paymentId, newStatus);
+
+        assertThat(updated.getStatus()).isEqualTo(newStatus);
+        assertThat(updated.getOrder().getStatus()).isEqualTo(Status.PAID);
+
+        verify(paymentRepository).save(payment);
+    }
+
+    @Test
+    void getById_shouldReturnPaymentIfUserMatches() {
+        Long paymentId = 3L;
+        User user = new User();
+        Order order = Order.builder().user(user).build();
+        Payment payment = Payment.builder().id(paymentId).order(order).build();
+
+        when(paymentRepository.findById(paymentId)).thenReturn(Optional.of(payment));
+        when(userService.getCurrentUser()).thenReturn(user);
+
+        Payment result = paymentService.getById(paymentId);
+
+        assertThat(result).isEqualTo(payment);
+        verify(paymentRepository).findById(paymentId);
+    }
+
+    @Test
+    void getAllByOrder_shouldReturnPaymentsIfUserMatches() {
+        Long orderId = 2L;
+        User user = new User();
+        Order order = Order.builder().orderId(orderId).user(user).build();
+
+        List<Payment> payments = List.of(new Payment(), new Payment());
+
+        when(orderService.getById(orderId)).thenReturn(order);
+        when(userService.getCurrentUser()).thenReturn(user);
+        when(paymentRepository.findAllByOrder(order)).thenReturn(payments);
+
+        List<Payment> result = paymentService.getAllByOrder(orderId);
+
+        assertThat(result).hasSize(2);
+        verify(paymentRepository).findAllByOrder(order);
+    }
+}


### PR DESCRIPTION
Добавлены unit-тесты для PaymentController, PaymentServiceImpl, PaymentConverter. 

Покрытие всех публичных методов. Используется Mockito.